### PR TITLE
Add position order for handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ goodbye(async function () {
 
 ## API
 
-#### `const unregister = goodbye(beforeExit)`
+#### `const unregister = goodbye(beforeExit, [position = 0])`
 
 Register an async function to be run before process exit.
 
@@ -32,6 +32,17 @@ All handlers are deregistered when the beforeExit method runs, which means if th
 
 Note that the function is NOT run if the user calls process.exit or if an unhandled error occurs - this is by design.
 Those events should exit the process in the same tick as their occur.
+
+## Position
+
+``` js
+goodbye(async () => console.log('last'), 2)
+goodbye(async () => console.log('last'), 2)
+goodbye(async () => console.log('first'), 0)
+goodbye(async () => console.log('middle'), 1)
+```
+
+The position value allows you to group handlers, they're executed and awaited by ascending order.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Those events should exit the process in the same tick as their occur.
 
 ``` js
 goodbye(async () => console.log('last'), 2)
-goodbye(async () => console.log('last'), 2)
 goodbye(async () => console.log('first'), 0)
 goodbye(async () => console.log('middle'), 1)
 ```

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function onexit () {
   process.removeListener('beforeExit', onexit)
 
   let promise = null
-  const positions = [...map.keys()].sort()
+  const positions = [...map.keys()].sort((a, b) => a - b)
 
   for (const pos of positions) {
     const handlers = map.get(pos)

--- a/index.js
+++ b/index.js
@@ -66,7 +66,6 @@ function goodbye (fn, position = 0) {
   return function unregister () {
     const i = handlers.indexOf(fn)
     if (i > -1) handlers.splice(i, 1)
-
     if (!handlers.length) {
       map.delete(position)
       if (!map.size) cleanup()

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function cleanup () {
 }
 
 function goodbye (fn, position = 0) {
-  if (!handlers.length) setup()
+  if (handlers.length === 0) setup()
   const handler = { position, fn }
   handlers.push(handler)
 


### PR DESCRIPTION
`onexit` function could be async and that would simplify the next/done part by just doing `await`, but I wanted to keep practically the same code for when it doesn't use positions.

Edit: it happened several times where I have multiple resources that I want to clean up but sometimes it's really important the order of terminating those resources, and they could be sparsed in different files, etc.

This reminds me of CSS property `z-index` but in reverse priority.