### PR TITLE
Log errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,16 @@ function onexit () {
   loop()
 
   function loop () {
+    const errPrinter = err => console.error('Error in graceful-goodbye handler:', err)
+
+    const processHandler = h => {
+      const res = Promise.resolve(h.fn()) //  guarantee promise, even if handler was sync
+      res.catch(errPrinter)
+      return res
+    }
+
     if (!order.length) return done()
-    Promise.allSettled(order.pop().map(h => h.fn())).then(loop, loop)
+    Promise.allSettled(order.pop().map(processHandler)).then(loop, loop)
   }
 
   function done () {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const safetyCatch = require('safety-catch')
+
 module.exports = goodbye
 
 const handlers = []
@@ -34,11 +36,9 @@ function onexit () {
   loop()
 
   function loop () {
-    const errPrinter = err => console.error('Error in graceful-goodbye handler:', err)
-
     const processHandler = h => {
       const res = Promise.resolve(h.fn()) //  guarantee promise, even if handler was sync
-      res.catch(errPrinter)
+      res.catch(safetyCatch)
       return res
     }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Run cleanup logic just before the process exits without interfering",
   "main": "index.js",
   "browser": "./browser.js",
-  "dependencies": {},
+  "dependencies": {
+    "safety-catch": "^1.0.2"
+  },
   "devDependencies": {
     "standard": "^16.0.4"
   },


### PR DESCRIPTION
If a handler errors out, those errors are swallowed, so it's not clear to the user that one of his close-handlers didn't complete. This PR logs all errors.

Note: Promise.resolve(...) was added to not make it a breaking change for sync handlers. If sync handlers are 100% not supported, then it can be removed (without Promise.resolve, res.catch(...) will throw)

